### PR TITLE
Fix order in README.md and add system requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,15 @@ Es basiert auf dem [Laravel-Framework](https://laravel.com/).
 Obwohl das MitarbeiterBoard ausschließlich für das Evangelische Schulzentrum Radebeul gedacht war, kann die Software frei für nicht-kommerzielle Projekte im Bereich der Bildung genutzt werden. Es gibt jedoch keinerlei Anspruch auf Support oder Haftung, sollten Schäden oder Probleme auftreten.
 Änderungen und Weiterentwicklungen sind ebenfalls als Open-Source zur Verfügung zu stellen.
 
+## Systemvoraussetzungen
+
+ * PHP 7.4
+ * Composer 2
+
 ## Installation
 
 Nach dem Upload der Dateien auf den Server ist zunächst die Datei ".env.example" in ".env" umzubenennen und auszufüllen. Entscheidend sind dabei die Eintragungen zu Datenbank und Mail-Server.
 
-Anschließend die Installation durchführen:
-
-```bash
-composer install
-```
-```bash
-php artisan key:generate
-```
-
-Bevor es weitergeht müssen ein paar Daten eingegeben werden. Dazu die Datei .env.example zu .env umbenennen bzw. kopieren: 
 
 ```bash
 cp .env.example .env
@@ -72,7 +67,14 @@ MAIL_FROM_ADDRESS=
 MAIL_FROM_NAME=
 
 
-Anschließend kann es weiter gehen:
+Anschließend die Installation durchführen:
+
+```bash
+composer install
+```
+```bash
+php artisan key:generate
+```
 
 ```bash
 php artisan webpush:vapid


### PR DESCRIPTION
Ich habe das MitarbeiterBoard erfolgreich und relativ geräuscharm unter Debian 10 installieren können. Vorausetzung ist allerdings, dass man auf PHP 7.4 aktualisiert und Composer 2.x installiert. Sonst hagelt es Composer-Probleme.

Ich habe das in der README.md ergänzt und auch die Dopplung entfernt, dass man die `.env.example` in `.env` umbenennen  und konfigurieren muss. Dieser Schritt ist unbedingt vor dem ersten `php artisan`-Aufruf notwendig. Kann aber schon vor dem `composer install` passieren.

Vielleicht hilft's jemand :-)